### PR TITLE
Update georefimage.cs

### DIFF
--- a/georefimage.cs
+++ b/georefimage.cs
@@ -668,8 +668,8 @@ namespace MissionPlanner
             using (StreamWriter swloctel = new StreamWriter(dirWithImages + Path.DirectorySeparatorChar + "location.tel"))
             using (XmlTextWriter swloctrim = new XmlTextWriter(dirWithImages + Path.DirectorySeparatorChar + "location.jxl", Encoding.ASCII))
              // added by Marco Fornalè - Export files for Ensomosaic integration
-            using (StreamWriter swlogtrp = new StreamWriter(dirWithImages + Path.DirectorySeparatorChar + "location.TRP"))
-            using (StreamWriter swloggps = new StreamWriter(dirWithImages + Path.DirectorySeparatorChar + "location.GPS"))
+            using (StreamWriter swlogtrp = new StreamWriter(dirWithImages + Path.DirectorySeparatorChar + "location.TRP",false, Encoding.GetEncoding(1250)))
+            using (StreamWriter swloggps = new StreamWriter(dirWithImages + Path.DirectorySeparatorChar + "location.GPS", false, Encoding.GetEncoding(1250)))
             // ------------- Marco Fornalè
             {
                 swloctrim.Formatting = Formatting.Indented;
@@ -812,12 +812,13 @@ namespace MissionPlanner
                 
                 // added by Marco Fornalè - adding the headers for TRP and GPS files for EnsoMosaic
                 // header for TRP file
-                swlogtrp.WriteLine("# Created by Marco Fornalè - "+DateTime.Now.ToString("MMM dd yyyy HH:mm:ss"));
+                swlogtrp.WriteLine("# Created by Marco Fornale' - "+DateTime.Now.ToString("MMM dd yyyy HH:mm:ss"));
+                swlogtrp.WriteLine("# Write the correct Average Altitude and Camera Rotation - replace the defaults");
                 swlogtrp.WriteLine("Projection: NUTM 27 WGS84 NoDatTra");
                 swlogtrp.WriteLine("Calibration_file: .\\camera.cal");
-                swlogtrp.WriteLine("Ground_control_point_file: NO.GCP");
+                swlogtrp.WriteLine("Ground_control_point_file: no.gcp");
                 swlogtrp.WriteLine("Approximate_terrain_altitude: 0.0");
-                swlogtrp.WriteLine("Camera_rotation: 180");
+                swlogtrp.WriteLine("Camera_rotation: 270");
                 swlogtrp.WriteLine("Map_files: 0");
 
                 // header for GPS file
@@ -928,7 +929,8 @@ namespace MissionPlanner
                     
                     // added by Marco Fornalè - Writing info to TRP and GPS files for Ensomosaic
                     swlogtrp.WriteLine("    1"+" "+ counter1 +" "+ filename +" \""+dirWithImages+"\"");
-                    swloggps.WriteLine("1" + "\t" + counter1 + "\t" + picInfo.Lon.ToString("00.000000").Replace(",", ".") + "\t" + picInfo.Lat.ToString("00.000000").Replace(",", ".") + "\t" + picInfo.RelAlt.ToString("0") + "\t" + picInfo.Yaw.ToString("0") + "\t" + picInfo.Time.ToString("MMM dd HH:mm:ss yyyy") + "\t" + picInfo.Yaw.ToString("0") + "\t" + picInfo.Pitch.ToString("0.0").Replace(",", ".") + "\t" + picInfo.Roll.ToString("0.0").Replace(",", ".") + "\t" + "ypr");
+                    swloggps.WriteLine("1" + "\t" + counter1 + "\t" + picInfo.Lon.ToString("00.000000").Replace(",", ".") + "\t" + picInfo.Lat.ToString("00.000000").Replace(",", ".") + "\t" + picInfo.getAltitude(useAMSLAlt).ToString("0") + "\t" + picInfo.Yaw.ToString("0") + "\t" + picInfo.Time.ToString("MMM dd HH:mm:ss yyyy",
+                  CultureInfo.CreateSpecificCulture("en-US")) + "\t" + picInfo.Yaw.ToString("0") + "\t" + picInfo.Pitch.ToString("0.0").Replace(",", ".") + "\t" + picInfo.Roll.ToString("0.0").Replace(",", ".") + "\t" + "ypr");
                     swlogtrp.Flush();
                     swloggps.Flush();
                     // end modification of Marco Fornalè


### PR DESCRIPTION
Files for Ensomosaic interface cannot be UTF-8, modified parameters of streamwriter.
Added one comment line in  TRP file header.
Used US Culture for date format in GPS file.
Now the files can be intergrated correctly by Ensomosaic UAV
